### PR TITLE
Fix include error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- include: setup-RedHat.yml
+- include_tasks: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
+- include_tasks: setup-Debian.yml
   when: ansible_distribution == 'Debian'
 
-- include: setup-Ubuntu.yml
+- include_tasks: setup-Ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
-- include: configuration.yml
+- include_tasks: configuration.yml


### PR DESCRIPTION
ansible.builtin.include has been removed from ansible-core after 2023-05-16; use include_tasks, instead.